### PR TITLE
Update logstash-output-sumologic.gemspec

### DIFF
--- a/logstash-output-sumologic.gemspec
+++ b/logstash-output-sumologic.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", "> 1.0"
   s.add_runtime_dependency "logstash-codec-plain"
   s.add_development_dependency "logstash-devutils"
 end


### PR DESCRIPTION
Logstash 5.0.0 use logstash-codec-plain that cause a dependency mismatch. As following.
Unable to resolve dependencies: logstash-output-sumologic requires logstash-core-plugin-api (~> 1.0); logstash-codec-plain requires logstash-core-plugin-api (<= 2.99, >= 1.60)