### PR TITLE
Fix logstash-codec-plain dependency

### DIFF
--- a/logstash-output-sumologic.gemspec
+++ b/logstash-output-sumologic.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = "logstash-output-sumologic"
-  s.version       = "1.1.0"
+  s.version       = "1.1.1"
   s.licenses      = ["Apache-2.0"]
   s.summary       = "Deliever the log to Sumo Logic cloud service."
   s.description   = "This gem is a Logstash output plugin to deliver the log or metrics to Sumo Logic cloud service. Go to https://github.com/SumoLogic/logstash-output-sumologic for getting help, reporting issues, etc."
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 2.0"
-  s.add_runtime_dependency "logstash-codec-plain", "~> 0"
+  s.add_runtime_dependency "logstash-codec-plain", ">= 0"
   s.add_development_dependency "logstash-devutils", "~> 0"
 end


### PR DESCRIPTION
I am unable to install with the current dependency using `logstash-codec-plain` 3.0.5