### PR TITLE
hostname fixing

### DIFF
--- a/lib/logstash/outputs/sumologic.rb
+++ b/lib/logstash/outputs/sumologic.rb
@@ -7,6 +7,7 @@ require 'thread'
 require "uri"
 require "zlib"
 require "stringio"
+require "socket"
 
 # Now you can use logstash to deliver logs to Sumo Logic
 #
@@ -101,7 +102,7 @@ class LogStash::Outputs::SumoLogic < LogStash::Outputs::Base
   
   public
   def register
-    @source_host = `hostname`.strip unless @source_host
+    @source_host = Socket.gethostname unless @source_host
 
     # initialize request pool
     @request_tokens = SizedQueue.new(@pool_max)

--- a/logstash-output-sumologic.gemspec
+++ b/logstash-output-sumologic.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = "logstash-output-sumologic"
-  s.version       = "1.1.2"
+  s.version       = "1.1.3"
   s.licenses      = ["Apache-2.0"]
   s.summary       = "Deliever the log to Sumo Logic cloud service."
   s.description   = "This gem is a Logstash output plugin to deliver the log or metrics to Sumo Logic cloud service. Go to https://github.com/SumoLogic/logstash-output-sumologic for getting help, reporting issues, etc."


### PR DESCRIPTION
https://github.com/SumoLogic/logstash-output-sumologic/issues/16
The `hostname` is not available on Windows. This fix is using `Socket. gethostname` to replace it