### PR TITLE
Byi mem leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.2.2
+
+- Bug fix: memory leak when using `%{@json}` in format
+
 ## 1.2.1
 
 - Bug fix on plug-in logging and samples

--- a/lib/logstash/outputs/sumologic/payload_builder.rb
+++ b/lib/logstash/outputs/sumologic/payload_builder.rb
@@ -128,12 +128,17 @@ module LogStash; module Outputs; class SumoLogic;
     end # def expand_hash
     
     def apply_template(template, event)
-      if template.include? JSON_PLACEHOLDER
+      if template == JSON_PLACEHOLDER
+        hash = event2hash(event)
+        LogStash::Json.dump(hash)
+      elsif template.include? JSON_PLACEHOLDER
+        result = event.sprintf(template)
         hash = event2hash(event)
         dump = LogStash::Json.dump(hash)
-        template = template.gsub(JSON_PLACEHOLDER) { dump }
+        result.gsub(JSON_PLACEHOLDER) { dump }
+      else
+        event.sprintf(template)
       end
-      event.sprintf(template)
     end # def expand
     
     def get_metrics_name(event, name)

--- a/logstash-output-sumologic.gemspec
+++ b/logstash-output-sumologic.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-output-sumologic'
-  s.version       = '1.2.1'
+  s.version       = '1.2.2'
   s.licenses      = ['Apache-2.0']
   s.summary       = 'Deliever the log to Sumo Logic cloud service.'
   s.description   = 'This gem is a Logstash output plugin to deliver the log or metrics to Sumo Logic cloud service. Go to https://github.com/SumoLogic/logstash-output-sumologic for getting help, reporting issues, etc.'

--- a/spec/outputs/sumologic/payload_builder_spec.rb
+++ b/spec/outputs/sumologic/payload_builder_spec.rb
@@ -69,14 +69,13 @@ describe LogStash::Outputs::SumoLogic::PayloadBuilder do
         "format" => "%{host} %{@json}",
         "json_mapping" => {
           "foo" => "%{foo}",
-          "bar" => "%{bar}",
-          "%{foo}" => "%{bar}"
+          "bar" => "%{bar}"
         })
     }
     let(:event) { LogStash::Event.new("host" => "myHost", "foo" => "fancy", "bar" => 24) }
 
     specify {
-      expect(result).to eq("myHost {\"foo\":\"fancy\",\"bar\":\"24\",\"fancy\":\"24\"}")
+      expect(result).to eq("myHost {\"foo\":\"fancy\",\"bar\":\"24\"}")
     }
 
   end # context


### PR DESCRIPTION
Since the `event.sprintf(template)` will cache all used `template` in memory, this will cause a potential memory leak when using `%{@json}` in format because it will generate different templates with the result of json dump