### PR TITLE
Fix "undefined method `blank?'"

### DIFF
--- a/lib/logstash/outputs/sumologic/common.rb
+++ b/lib/logstash/outputs/sumologic/common.rb
@@ -69,5 +69,15 @@ module LogStash; module Outputs; class SumoLogic;
       end
     end # def log_dbg
 
+    def blank?(value)
+      if value.kind_of?(NilClass)
+        true
+      elsif value.kind_of?(String)
+        value !~ /\S/
+      else
+        value.respond_to?(:empty?) ? value.empty? : !value
+      end
+    end
+
   end
 end; end; end

--- a/lib/logstash/outputs/sumologic/header_builder.rb
+++ b/lib/logstash/outputs/sumologic/header_builder.rb
@@ -25,9 +25,9 @@ module LogStash; module Outputs; class SumoLogic;
       headers = Hash.new
       headers.merge!(@extra_headers)
       headers[CLIENT_HEADER] = CLIENT_HEADER_VALUE
-      headers[CATEGORY_HEADER] = event.sprintf(@source_category) unless @source_category.blank?
-      headers[HOST_HEADER] = event.sprintf(@source_host) unless @source_host.blank?
-      headers[NAME_HEADER] = event.sprintf(@source_name) unless @source_name.blank?
+      headers[CATEGORY_HEADER] = event.sprintf(@source_category) unless blank?(@source_category)
+      headers[HOST_HEADER] = event.sprintf(@source_host) unless blank?(@source_host)
+      headers[NAME_HEADER] = event.sprintf(@source_name) unless blank?(@source_name)
       append_content_header(headers)
       append_compress_header(headers)
       headers

--- a/lib/logstash/outputs/sumologic/piler.rb
+++ b/lib/logstash/outputs/sumologic/piler.rb
@@ -67,7 +67,7 @@ module LogStash; module Outputs; class SumoLogic;
               @queue.enq(Batch.new(headers, content))
               @pile[headers] = ""
             end
-            @pile[headers] = @pile[headers].blank? ? payload : "#{@pile[headers]}\n#{payload}"
+            @pile[headers] = blank?(@pile[headers]) ? payload : "#{@pile[headers]}\n#{payload}"
           }
         else
           @queue.enq(Batch.new(headers, payload))


### PR DESCRIPTION
When running the `samples/file-input-example` on `docker.elastic.co/logstash/logstash-oss:7.9.3` image, I'm getting the following errors:
```console
2020-12-18 09:45:24.622 ERROR [[main]>worker1] [logstash.outputs.sumologic] error when processing event {:event=>#<LogStash::Event:0x229cafd>, :message=>"undefined method `blank?' for \"Logstash\":String", :class=>"NoMethodError", :backtrace=>["/usr/share/logstash/vendor/local_gems/ba86d2b9/logstash-output-sumologic-1.3.0/lib/logstash/outputs/sumologic/header_builder.rb:28:in `build'", "/usr/share/logstash/vendor/local_gems/ba86d2b9/logstash-output-sumologic-1.3.0/lib/logstash/outputs/sumologic/piler.rb:60:in `input'", "/usr/share/logstash/vendor/local_gems/ba86d2b9/logstash-output-sumologic-1.3.0/lib/logstash/outputs/sumologic.rb:141:in `receive'", "/usr/share/logstash/vendor/local_gems/ba86d2b9/logstash-output-sumologic-1.3.0/lib/logstash/outputs/sumologic.rb:136:in `block in multi_receive'", "org/jruby/RubyArray.java:2577:in `map'", "/usr/share/logstash/vendor/local_gems/ba86d2b9/logstash-output-sumologic-1.3.0/lib/logstash/outputs/sumologic.rb:136:in `multi_receive'", "org/logstash/config/ir/compiler/OutputStrategyExt.java:138:in `multi_receive'", "org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java:121:in `multi_receive'", "/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:295:in `block in start_workers'"]}
2020-12-18 09:45:24.622 ERROR [[main]>worker2] [logstash.outputs.sumologic] error when processing event {:event=>#<LogStash::Event:0x74ee4c9b>, :message=>"undefined method `blank?' for \"Logstash\":String", :class=>"NoMethodError", :backtrace=>["/usr/share/logstash/vendor/local_gems/ba86d2b9/logstash-output-sumologic-1.3.0/lib/logstash/outputs/sumologic/header_builder.rb:28:in `build'", "/usr/share/logstash/vendor/local_gems/ba86d2b9/logstash-output-sumologic-1.3.0/lib/logstash/outputs/sumologic/piler.rb:60:in `input'", "/usr/share/logstash/vendor/local_gems/ba86d2b9/logstash-output-sumologic-1.3.0/lib/logstash/outputs/sumologic.rb:141:in `receive'", "/usr/share/logstash/vendor/local_gems/ba86d2b9/logstash-output-sumologic-1.3.0/lib/logstash/outputs/sumologic.rb:136:in `block in multi_receive'", "org/jruby/RubyArray.java:2577:in `map'", "/usr/share/logstash/vendor/local_gems/ba86d2b9/logstash-output-sumologic-1.3.0/lib/logstash/outputs/sumologic.rb:136:in `multi_receive'", "org/logstash/config/ir/compiler/OutputStrategyExt.java:138:in `multi_receive'", "org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java:121:in `multi_receive'", "/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:295:in `block in start_workers'"]}
2020-12-18 09:45:24.623 ERROR [[main]>worker6] [logstash.outputs.sumologic] error when processing event {:event=>#<LogStash::Event:0x26c59e92>, :message=>"undefined method `blank?' for \"Logstash\":String", :class=>"NoMethodError", :backtrace=>["/usr/share/logstash/vendor/local_gems/ba86d2b9/logstash-output-sumologic-1.3.0/lib/logstash/outputs/sumologic/header_builder.rb:28:in `build'", "/usr/share/logstash/vendor/local_gems/ba86d2b9/logstash-output-sumologic-1.3.0/lib/logstash/outputs/sumologic/piler.rb:60:in `input'", "/usr/share/logstash/vendor/local_gems/ba86d2b9/logstash-output-sumologic-1.3.0/lib/logstash/outputs/sumologic.rb:141:in `receive'", "/usr/share/logstash/vendor/local_gems/ba86d2b9/logstash-output-sumologic-1.3.0/lib/logstash/outputs/sumologic.rb:136:in `block in multi_receive'", "org/jruby/RubyArray.java:2577:in `map'", "/usr/share/logstash/vendor/local_gems/ba86d2b9/logstash-output-sumologic-1.3.0/lib/logstash/outputs/sumologic.rb:136:in `multi_receive'", "org/logstash/config/ir/compiler/OutputStrategyExt.java:138:in `multi_receive'", "org/logstash/config/ir/compiler/AbstractOutputDelegatorExt.java:121:in `multi_receive'", "/usr/share/logstash/logstash-core/lib/logstash/java_pipeline.rb:295:in `block in start_workers'"]}
```

This code seems to work fine in Logstash 6.8.9.

Logstash 7 has a [LogStash::Util.blank?](https://github.com/elastic/logstash/blob/d176e608bdd20a3221bdbb8b3fc84fc3f1085229/logstash-core/lib/logstash/util.rb#L228) method which we could use, but it is unavailable in Logstash 6, so using it would restrict this plugin's usage to only Logstash 7 and above. To be able to support Logstash 6, I replicated the `LogStash::Util.blank?` method in this plugin as `LogStash::Output::Sumologic::Common.blank?`.