### PR TITLE
Fix plugin metrics not being sent

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Logon to Sumo Logic [web app](https://service.sumologic.com/) and run
 | `fields_include`       | array   | No        | all fields    | Working with `fields_as_metrics` parameter, only the fields which full name matching these RegEx pattern(s) will be included in metrics.
 | `fields_exclude`       | array   | No        | none          | Working with `fields_as_metrics` parameter, the fields which full name matching these RegEx pattern(s) will be ignored in metrics.
 | `sleep_before_requeue` | number  | No        | `30`          | The message failed to send to server will be retried after (x) seconds. Not retried if negative number set
+| `stats_category`       | string  | No        | `Logstash.stats` | The source category this plugin's stats will be sent with when `stats_enabled` is `true`
 | `stats_enabled`        | boolean | No        | `false`       | If `true`, stats of this plugin will be sent as metrics
 | `stats_interval`       | number  | No        | `60`          | The stats will be sent every (x) seconds
 
@@ -136,7 +137,7 @@ On the other side, this version is marked as thread safe so if necessary, multip
 
 ### Monitor throughput in metrics
 
-If your Sumo Logic account supports metrics feature, you can enable the stats monitor of this plugin with configuring `stats_enabled` to `true`. For every `stats_interval` seconds, a batch of metrics data points will be sent to Sumo Logic with source category `XXX.stats` (`XXX` is the source category of main output):
+If your Sumo Logic account supports metrics feature, you can enable the stats monitor of this plugin with configuring `stats_enabled` to `true`. For every `stats_interval` seconds, a batch of metrics data points will be sent to Sumo Logic with source category specified by `stats_category` parameter:
 
 | Metric                          | Description                                                 |
 | ------------------------------- | ----------------------------------------------------------- |

--- a/lib/logstash/outputs/sumologic.rb
+++ b/lib/logstash/outputs/sumologic.rb
@@ -105,6 +105,8 @@ class LogStash::Outputs::SumoLogic < LogStash::Outputs::Base
   # For messages fail to send or get 429/503/504 response, try to resend after (x) seconds; don't resend if (x) < 0
   config :sleep_before_requeue, :validate => :number, :default => 30
 
+  config :stats_category, :validate => :string, :default => CATEGORY_HEADER_DEFAULT_STATS
+
   # Sending throughput data as metrics
   config :stats_enabled, :validate => :boolean, :default => false
 

--- a/lib/logstash/outputs/sumologic/common.rb
+++ b/lib/logstash/outputs/sumologic/common.rb
@@ -22,6 +22,7 @@ module LogStash; module Outputs; class SumoLogic;
 
     CATEGORY_HEADER = "X-Sumo-Category"
     CATEGORY_HEADER_DEFAULT = "Logstash"
+    CATEGORY_HEADER_DEFAULT_STATS = "Logstash.stats"
     HOST_HEADER = "X-Sumo-Host"
     NAME_HEADER = "X-Sumo-Name"
     NAME_HEADER_DEFAULT = "logstash-output-sumologic"

--- a/lib/logstash/outputs/sumologic/header_builder.rb
+++ b/lib/logstash/outputs/sumologic/header_builder.rb
@@ -11,6 +11,7 @@ module LogStash; module Outputs; class SumoLogic;
       
       @extra_headers = config["extra_headers"] ||= {}
       @source_category = config["source_category"] ||= CATEGORY_HEADER_DEFAULT
+      @stats_category = config["stats_category"] ||= CATEGORY_HEADER_DEFAULT_STATS
       @source_host = config["source_host"] ||= Socket.gethostname
       @source_name = config["source_name"] ||= NAME_HEADER_DEFAULT
       @metrics = config["metrics"]
@@ -32,6 +33,18 @@ module LogStash; module Outputs; class SumoLogic;
       append_compress_header(headers)
       headers
     end # def build
+
+    def build_stats()
+      headers = Hash.new
+      headers.merge!(@extra_headers)
+      headers[CLIENT_HEADER] = CLIENT_HEADER_VALUE
+      headers[CATEGORY_HEADER] = @stats_category
+      headers[HOST_HEADER] = Socket.gethostname
+      headers[NAME_HEADER] = NAME_HEADER_DEFAULT
+      headers[CONTENT_TYPE] = CONTENT_TYPE_CARBON2 
+      append_compress_header(headers)
+      headers
+    end # def build_stats
 
     private
     def append_content_header(headers)

--- a/lib/logstash/outputs/sumologic/sender.rb
+++ b/lib/logstash/outputs/sumologic/sender.rb
@@ -102,8 +102,6 @@ module LogStash; module Outputs; class SumoLogic;
 
       if @stats_enabled && content.start_with?(STATS_TAG)
         body = @compressor.compress(content[STATS_TAG.length..-1])
-        headers[CATEGORY_HEADER] = "#{headers[CATEGORY_HEADER]}.stats"
-        headers[CONTENT_TYPE] = CONTENT_TYPE_CARBON2
       else
         body = @compressor.compress(content)
       end


### PR DESCRIPTION
Fixes #59.

This fix does not resolve the issue that the metrics `total_input_events` and `total_input_bytes` are not being calculated. This will be fixed separately.