### PR TITLE
chore: change k8s.gcr.io registry to registry.k8s.io

### DIFF
--- a/deploy/kubernetes/kube-state-metrics.yaml
+++ b/deploy/kubernetes/kube-state-metrics.yaml
@@ -38,7 +38,7 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 5
       - name: addon-resizer
-        image: k8s.gcr.io/addon-resizer:1.8.3
+        image: registry.k8s.io/addon-resizer:1.8.3
         resources:
           limits:
             cpu: 150m


### PR DESCRIPTION
https://kubernetes.io/blog/2023/03/10/image-registry-redirect/