### PR TITLE
chore: add vagrant for arm

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,15 +1,9 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-unless Vagrant.has_plugin?("vagrant-disksize")
-  puts "vagrant-disksize plugin unavailable\n" +
-       "please install it via 'vagrant plugin install vagrant-disksize'"
-  exit 1
-end
-
 Vagrant.configure('2') do |config|
   config.vm.box = 'ubuntu/focal64'
-  config.disksize.size = '50GB'
+  config.vm.disk :disk, size: "50GB", primary: true
   config.vm.box_check_update = false
   config.vm.host_name = 'logstash-output-sumologic'
   # Vbox 6.1.28+ restricts host-only adapters to 192.168.56.0/21
@@ -21,6 +15,14 @@ Vagrant.configure('2') do |config|
     vb.cpus = 8
     vb.memory = 16384
     vb.name = 'logstash-output-sumologic'
+  end
+
+  config.vm.provider "qemu" do |qe, override|
+    override.vm.box = "perk/ubuntu-2204-arm64"
+    qe.gui = false
+    qe.smp = 8
+    qe.memory = 16384
+    qe.name = 'logstash-output-sumologic'
   end
 
   config.vm.provision 'shell', path: 'vagrant/provision.sh', privileged: false

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -6,14 +6,12 @@ Please install the following:
 
 - [VirtualBox](https://www.virtualbox.org/)
 - [Vagrant](https://www.vagrantup.com/)
-- [vagrant-disksize](https://github.com/sprotheroe/vagrant-disksize) plugin
 
 To install the prerequisites on MacOS with Homebrew:
 
 ```bash
 brew cask install virtualbox
 brew cask install vagrant
-vagrant plugin install vagrant-disksize
 ```
 
 ## Setting up

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -3,6 +3,8 @@
 set -x
 
 export DEBIAN_FRONTEND=noninteractive
+ARCH="$(dpkg --print-architecture)"
+
 sudo apt-get update
 sudo apt-get --yes upgrade
 
@@ -11,11 +13,11 @@ echo "export EDITOR=vim" >> ~/.bashrc
 # Install Docker
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 echo \
-  "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+  "deb [arch=${ARCH} signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt update
 sudo apt-get install -y docker-ce docker-ce-cli containerd.io
-usermod -aG docker vagrant
+sudo usermod -aG docker vagrant
 
 # start receiver-mock
 sudo docker create -p 3000:3000 --name receiver-mock --restart=always sumologic/kubernetes-tools receiver-mock --print-headers


### PR DESCRIPTION
Two significant changes:

1. run usermod with root
1. Fix receiver-mock to 2.9.0 as this is latest version which supports GET without Content-Type